### PR TITLE
rework `Confit::confit` method args for nesting and blocks

### DIFF
--- a/confit.gemspec
+++ b/confit.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name        = "confit"
-  s.version     = "1.0.1"
-  s.authors     = ['Jen Oslislo']
-  s.email       = ["twitterpoeks@gmail.com"]
+  s.version     = "1.1.0"
+  s.authors     = ['Jen Oslislo', 'Kenichi Nakamura']
+  s.email       = ["twitterpoeks@gmail.com, kenichi.nakamura@gmail.com"]
   s.homepage    = "https://github.com/poeks/confit"
   s.summary     = "A teeny, tiny configuration manager for YAML config files."
   s.description = "A teeny, tiny configuration manager for YAML config files."

--- a/lib/confit.rb
+++ b/lib/confit.rb
@@ -6,72 +6,77 @@ class MissingVariableError < StandardError; end
 class MissingFileError < StandardError; end
 
 module Confit
-  
+
   @@app_config = nil
-  @@strict = nil
+  @@strict = false
   @@files = Array.new
   @@current_file_name = nil
   @@debug = false
-  
+  @@default_opts = lambda { return {:strict => @@strict, :force => false} }
+
   def self.debug(msg)
     puts "\nDebug:\t#{msg}" if @@debug
   end
-  
+
   def self.strict
     @@strict
   end
 
-  def self.prep_key(key)
-    key.gsub(/\s/, "_")
-  end
-  
-  def self.confit(file=nil, env=nil, strict=false, force=false)
-    self.debug("self.confit(file=#{file}, env=#{env}, strict=#{strict}, force=#{force})")
-    
-    @@app_config = OpenStruct.new if not @@app_config
-    
+  def self.confit(*args, &block)
+    file = args.shift
+    opts = (args.last and args.last.is_a? Hash) ? args.pop : @@default_opts.call
+    env = (args && args.compact) || []
+
+    self.debug("self.confit(file=#{file}, env=#{env}, strict=#{opts[:strict]}, force=#{opts[:force]})")
+
+    @@app_config ||= OpenStruct.new
+
     if not @@files.include?(file) and not file.nil?
       self.debug "New file: #{file}"
       self.prep_config(file)
     else
-      self.debug "File exists: (#{force}) #{file}"
-      return @@app_config if not force
+      self.debug "File exists: (#{opts[:force]}) #{file}"
+      return @@app_config unless opts[:force]
       self.debug "Forcing reload of file"
     end
-    
-    @@strict = strict ? true : false
-    
-    self.process_file(file, env)
+
+    @@strict = opts[:strict] ? true : false
+
+    self.process_file(file, env, &block)
 
     @@app_config
   end
-  
+
   def self.prep_config(file)
     file =~ /([^\/]+)\.yml$/i
     raise InvalidFileNameError, "Filename is not valid: #{file}" if not $1
-    
+
     @@current_file_name = $1
     self.debug "Current file #{@@current_file_name}"
     @@files << file
-    @@app_config.send("#{@@current_file_name}=", OpenStruct.new)  
+    @@app_config.send("#{@@current_file_name}=", OpenStruct.new)
   end
-  
+
   def self.process_file(file, env=nil)
     if not file.nil?
       if File.exist?(file)
-        yaml = env ? YAML.load_file(file)[env] : YAML.load_file(file)
+        #yaml = env ? YAML.load_file(file)[env] : YAML.load_file(file)
+        yaml = YAML.load_file(file)
+        env.each {|key| yaml = yaml[key.to_s]}
+        yield yaml if block_given?
         self.parse_hash(yaml, @@app_config.send(@@current_file_name))
       else
         raise MissingFileError, "File #{file} does not exist!"
       end
     end
   end
-  
+
   def self.load_pair(key, val, parent)
-    self.debug "load_pair: #{parent}.send(#{key}=, #{val})"
-    parent.send("#{key}=", val)
+    _key = key.gsub /\s+/, '_'
+    self.debug "load_pair: #{parent}.send(#{_key}=, #{val})"
+    parent.send("#{_key}=", val)
   end
-  
+
   def self.parse_hash(zee_hash, parent)
     zee_hash.each do |key, val|
       if val.is_a?(Hash)
@@ -82,14 +87,21 @@ module Confit
         self.debug "Not a Hash #{key},#{val}"
         self.load_pair(key, val, parent)
       end
-      
+
     end
   end
-  
+
+  def self.reset!
+    @@app_config = nil
+    @@strict = false
+    @@files = Array.new
+    @@current_file_name = nil
+  end
+
 end
 
 class OpenStruct
-  
+
   def method_missing(mid, *args)
     mname = mid.id2name
     if mname !~ /=/
@@ -108,5 +120,5 @@ class OpenStruct
       end
     end
   end
-  
+
 end

--- a/lib/confit/kernel.rb
+++ b/lib/confit/kernel.rb
@@ -1,9 +1,9 @@
 require 'confit'
 
 module Kernel
-  
-  def confit(file=nil, env=nil, strict=false, force=false)
-    Confit::confit(file, env, strict, force)
+
+  def confit(*args, &block)
+    Confit::confit(*args, &block)
   end
 
 end

--- a/test/complex.yml
+++ b/test/complex.yml
@@ -24,3 +24,11 @@ poeks_dev:
   a_hash: 
     name: the hash
     value: the value
+
+foo:
+  bar:
+    num: 1
+    boo: false
+  baz:
+    num: 2
+    boo: true

--- a/test/confit_test.rb
+++ b/test/confit_test.rb
@@ -1,35 +1,64 @@
 require File.join(File.expand_path(File.join(File.dirname(__FILE__))), '..', 'lib', 'confit')
 
 require 'test/unit'
+require 'yaml'
 
 class ConfitTest < Test::Unit::TestCase
 
+  @@simple = File.join(File.expand_path(File.join(File.dirname(__FILE__))), 'simple.yml')
+  @@complex = File.join(File.expand_path(File.join(File.dirname(__FILE__))), 'complex.yml')
+
+  def setup
+    Confit.reset!
+  end
+
   def test_missing
-    file = File.join(File.expand_path(File.join(File.dirname(__FILE__))), '..', 'test', 'simple.yml')
-    confit(file, 'dev', true)
-    puts "Doesn't exist: #{confit.test.your_mom}"
+    Confit::confit(@@simple, 'dev', :strict => true)
+    puts "Doesn't exist: #{Confit::confit.test.your_mom}"
   rescue MissingVariableError => e
     assert_equal(e.class.to_s, "MissingVariableError")
   end
-  
+
   def test_simple
-    file = File.join(File.expand_path(File.join(File.dirname(__FILE__))), '..', 'test', 'simple.yml')
-    confit(file, 'dev', true)
-    assert_equal("Poeks", confit.simple.author)
+    Confit::confit(@@simple, 'dev', :strict => true)
+    assert_equal("Poeks", Confit::confit.simple.author)
   end
 
   def test_complex
-    file = File.join(File.expand_path(File.join(File.dirname(__FILE__))), '..', 'test', 'complex.yml')
-    confit(file, nil, true)
-    assert_equal("the value", confit.complex.poeks_dev.a_hash.value)
+    Confit::confit(@@complex, nil, :strict => true)
+    assert_equal("the value", Confit::confit.complex.poeks_dev.a_hash.value)
   end
-  
+
   def test_force
-    file = File.join(File.expand_path(File.join(File.dirname(__FILE__))), '..', 'test', 'complex.yml')
-    confit(file, 'jo_dev', true, true)
-    assert_equal("jo dev", confit.complex.app_name)
-    confit(file, 'poeks_dev', true, true)
-    assert_equal("poeks dev", confit.complex.app_name)
+    Confit::confit(@@complex, 'jo_dev', :strict => true, :force => true)
+    assert_equal("jo dev", Confit::confit.complex.app_name)
+    Confit::confit(@@complex, 'poeks_dev', :strict => true, :force => true)
+    assert_equal("poeks dev", Confit::confit.complex.app_name)
   end
-  
+
+  def test_key_with_spaces
+    Confit::confit(@@simple, 'dev', :strict => true)
+    assert_equal "Now underscores", Confit::confit.simple.a_key_with_spaces
+  end
+
+  def test_nesting
+    Confit::confit(@@complex, 'foo', 'bar', :strict => false)
+    assert_equal 1, Confit::confit.complex.num
+    assert_equal false, Confit::confit.complex.boo
+    Confit::confit(@@complex, 'foo', 'baz', :force => true)
+    assert_equal 2, Confit::confit.complex.num
+    assert_equal true, Confit::confit.complex.boo
+  end
+
+  def test_block
+    Confit::confit @@complex, 'foo', 'bar', :strict => false do |pre_parse_hash|
+      pre_parse_hash['boo_is_false'] = !pre_parse_hash['boo']
+    end
+    assert Confit::confit.complex.boo_is_false
+    Confit::confit @@complex, 'foo', 'baz', :force => true do |pre_parse_hash|
+      pre_parse_hash['boo_is_false'] = !pre_parse_hash['boo']
+    end
+    assert !Confit::confit.complex.boo_is_false
+  end
+
 end


### PR DESCRIPTION
* supports arbitrary nesting of yaml "hashes"
* supports block access to hash before it parses into the OpenStruct

tested on MRI 1.8.7, 1.9.2, and 1.9.3